### PR TITLE
Update OSX install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ From your GOPATH:
 
         $ brew install sdl --with-x11-driver
         $ brew install sdl_gfx sdl_image glew
-        $ brew edit sdl
         $ go get github.com/scottferg/Fergulator
 
 ## Run the emulator


### PR DESCRIPTION
It wasn't specified what this file was supposed to be edited to. And it had already been used to install, so this would be too late to do it. And it works without it.